### PR TITLE
fix block event cancel logic

### DIFF
--- a/overrides/kubejs/server_scripts/mobs/CDF_Mob_Ordinance.js
+++ b/overrides/kubejs/server_scripts/mobs/CDF_Mob_Ordinance.js
@@ -23,10 +23,10 @@ BlockEvents.placed(event => {
 
   if (level.isClientSide && level.isClientSide()) return
   if (level.dimension != 'minecraft:the_nether') return
-  if (block.id == 'minecraft:spawner')
-  if (block.y <= NETHER_ROOF_Y) return
- 
-  event.cancel()
+  if (block.id == 'minecraft:spawner') {
+    if (block.y <= NETHER_ROOF_Y) return
+    event.cancel()
+  }
 })
 
 BlockEvents.rightClicked(event => {


### PR DESCRIPTION
to correctly block minecraft:spawner for Y height 120 and above